### PR TITLE
[Issue/Fix]: 스레드당 별도 커넥션 설정 및 커넥션 풀 조정

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -5,7 +5,7 @@
 #include <mysql/mysql.h>
 #include <stdio.h>
 
-static MYSQL *conn = NULL;
+static __thread MYSQL *conn = NULL;
 
 // 1) 커넥션 초기화
 bool db_init(const char *host, const char *user,

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#include <mysql/mysql.h>
 
 #include "account.h"
 #include "db.h"           
@@ -24,16 +25,19 @@ void handle_sigint(int signo) {
 }
 
 int main(void) {
-    // 1) SIGINT 핸들러 등록
+    // SIGINT 핸들러 등록
     signal(SIGINT, handle_sigint);
 
-    // 2) 계좌 모듈 초기화 (MySQL 커넥션 연결)
+    // MYSQL 클라이언트 라이브러리 전역 초기화
+    mysql_library_init(0, NULL, NULL);
+
+    // 계좌 모듈 초기화 (MySQL 커넥션 연결)
     account_module_init();
 
-    // 3) 스레드풀 초기화
+    // 스레드풀 초기화
     threadpool_init();
 
-    // 4) 서버 소켓 생성 · 바인드 · 리스닝
+    // 서버 TCP 소켓 생성 · 바인드 · 리스닝
     struct sockaddr_in addr = {
         .sin_family      = AF_INET,
         .sin_addr.s_addr = INADDR_ANY,

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -1,6 +1,9 @@
 // src/threadpool.c
 #include "threadpool.h"
 #include "http.h"            // handle_connection() 선언
+#include "db.h"
+
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>


### PR DESCRIPTION
## 요약
기존에는 모든 워커 스레드가 전역 `MYSQL *conn` 을 공유하며, 동시 요청 시 “double free” 또는 “Lost connection” 오류가 발생했습니다.  
이 PR은 각 스레드가 독립된 MySQL 커넥션을 사용하도록 수정합니다.

---

## 변경 사항
1. **db.c**  
   - `static MYSQL *conn` → `static __thread MYSQL *conn` (스레드 로컬 저장)  

2. **main.c**  
   - 프로세스 시작 시 `mysql_library_init(0, NULL, NULL)` 호출 (MySQL 라이브러리 전역 초기화)  

3. **threadpool.c**  
   - 상단에 `#include <stdio.h>` 및 `#include "db.h"` 추가  
   - `worker_loop()` 진입부에:
     ```c
     mysql_thread_init();         // 스레드 전용 MySQL 내부 데이터 초기화
     db_init(...);                // TLS conn으로 개별 커넥션 생성
     ```
   - 루프 종료(사실상 도달하지 않음) 직전에:
     ```c
     db_close();                  // 스레드 전용 커넥션 종료
     mysql_thread_end();          // mysql_thread_init 짝
     ```

---

## ✅ 검증 방법
```bash
make clean && make
# 8개의 병렬 요청 테스트

seq 1 8 | xargs -P8 -I{} curl -s -X POST http://localhost:9090/deposit \
  -H "Content-Type: application/json" \
  -d '{"account":1001,"amount":1}'
