### PR TITLE
Feat/10: 계좌 조회 API 추가 및 입출금 API 수정(계좌번호 기준)

### DIFF
--- a/include/account.h
+++ b/include/account.h
@@ -7,8 +7,9 @@
 
 #define MAX_ACCOUNTS 1024
 
+// In-Memory 기반 Account 모델
 typedef struct {
-    int             id;        // 계좌 번호
+    int             id;        // 계좌 식별 ID
     long            balance;   // 잔액
     pthread_mutex_t mtx;       // 동시성 제어용 뮤텍스
 } Account;
@@ -16,11 +17,14 @@ typedef struct {
 // 모듈 초기화: 뮤텍스 초기화 및 예시 계좌 세팅
 void account_module_init(void);
 
-// 입금 처리: 성공 0, 계좌 없음 -2
-int account_deposit(int id, long amount, long *new_balance);
+// 입금 처리 (account_number 기준)
+int account_deposit(const char *acct_num, long amount, long *new_balance);
 
-// 출금 처리: 성공 0, 잔액 부족 -1, 계좌 없음 -2
-int account_withdraw(int id, long amount, long *new_balance);
+// 출금 처리 (account_number 기준)
+int account_withdraw(const char *acct_num, long amount, long *new_balance);
+
+// 잔액 조회 (account_number 기준)
+int account_get_balance(const char *acct_num, long *balance);
 
 #endif // ACCOUNT_H
 

--- a/include/db.h
+++ b/include/db.h
@@ -18,30 +18,38 @@ bool db_init(const char *host,
              const char *db,
              unsigned int port);
 
-// 2) 입금 처리
-//    id: 계좌 번호
+// 2) 입금 처리 (account_number 기준)
+//    acct_num: 계좌번호 문자열
 //    amount: 입금액
-//    new_balance: 갱신된 잔액을 저장할 포인터
+//    new_balance: 갱신된 잔액 저장 포인터
 //  → 리턴값:
 //     0  = 성공
 //    -2  = 계좌 없음
 //    -1  = 그 외(DB 오류)
-int db_deposit(int id, long amount, long *new_balance);
+int db_deposit_by_number(const char *acct_num, long amount, long *new_balance);
 
-// 3) 출금 처리
-//    id: 계좌 번호
+// 3) 출금 처리 (account_number 기준)
+//    acct_num: 계좌번호 문자열
 //    amount: 출금액
-//    new_balance: 갱신된 잔액을 저장할 포인터
+//    new_balance: 갱신된 잔액 저장 포인터
 //  → 리턴값:
 //     0  = 성공
 //    -1  = 잔액 부족
 //    -2  = 계좌 없음
 //    -1  = 그 외(DB 오류)
-int db_withdraw(int id, long amount, long *new_balance);
+int db_withdraw_by_number(const char *acct_num, long amount, long *new_balance);
 
-// 4) 종료 처리
+// 4) 잔액 조회 (account_number 기준)
+//    acct_num: 계좌번호 문자열
+//    balance: 조회된 잔액 저장 포인터
+//  → 리턴값:
+//     0  = 성공
+//    -2 = 계좌 없음
+//    -1 = 그 외(DB 오류)
+int db_get_balance(const char *acct_num, long *balance);
+
+// 5) 종료 처리
 //    프로그램 종료 시 호출해서 DB 커넥션을 닫음
 void db_close(void);
 
 #endif // DB_H
-

--- a/include/json_util.h
+++ b/include/json_util.h
@@ -4,13 +4,21 @@
 
 #include <stddef.h>
 
-// JSON 요청 바디에서 'account' (int)와 'amount' (long) 값을 파싱합니다.
-// body: JSON 문자열(null-terminated)
-// out_account, out_amount: 파싱된 값을 저장할 포인터
+// 거래 요청 파싱: account_number (문자열) 과 amount (숫자) 추출
 // 반환값:
 //   0  - 성공
 //  -1  - JSON 파싱 실패
 //  -2  - 필드 누락 또는 타입 불일치
-int parse_request(const char *body, int *out_account, long *out_amount);
+int parse_tx_request(const char *body,
+                     char *out_acct_num, size_t max_len,
+                     long *out_amount);
+
+// 잔액 조회 요청 파싱: account_number (문자열) 추출
+// 반환값:
+//   0  - 성공
+//  -1  - JSON 파싱 실패
+//  -2  - 필드 누락 또는 타입 불일치
+int parse_balance_request(const char *body,
+                          char *out_acct_num, size_t max_len);
 
 #endif // JSON_UTIL_H

--- a/src/account.c
+++ b/src/account.c
@@ -21,12 +21,16 @@ void account_module_init(void) {
 }
 
 // HTTP handler에서 호출: DB에 트랜잭션 단위로 입금 처리
-int account_deposit(int id, long amount, long *new_balance) {
-    return db_deposit(id, amount, new_balance);
+int account_deposit(const char *acct_num, long amount, long *new_balance) {
+    return db_deposit_by_number(acct_num, amount, new_balance);
 }
 
 // HTTP handler에서 호출: DB에 트랜잭션 단위로 출금 처리
-int account_withdraw(int id, long amount, long *new_balance) {
-    return db_withdraw(id, amount, new_balance);
+int account_withdraw(const char *acct_num, long amount, long *new_balance) {
+    return db_withdraw_by_number(acct_num, amount, new_balance);
 }
 
+// HTTP handler에서 호출: 계좌 잔액조회(계좌번호 + 잔액)
+int account_get_balance(const char *acct_num, long *balance) {
+    return db_get_balance(acct_num, balance);
+}

--- a/src/json_util.c
+++ b/src/json_util.c
@@ -1,36 +1,58 @@
 // src/json_util.c
 
 #include <stdio.h>
+#include <string.h>
 #include "json_util.h"
 #include "cJSON.h"
-#define LOG_ERR(fmt, ...) \
-    fprintf(stderr, "[ERROR] " fmt " (%s:%d)\n", ##__VA_ARGS__, __FILE__, __LINE__)
 
-int parse_request(const char *body, int *out_account, long *out_amount) {
-    if (!body || !out_account || !out_amount){
-	LOG_ERR("parse_request: null argument");
-	return -1;
-    }
-    // JSON 파싱
-    cJSON *root = cJSON_Parse(body);
-    if (!root){
-	LOG_ERR("parse_request: JSON parse failed (invalid JSON)");
+// 거래 요청 파싱 (account_number, amount)
+int parse_tx_request(const char *body,
+                     char *out_acct_num, size_t max_len,
+                     long *out_amount) {
+    if (!body || !out_acct_num || !out_amount) {
+        fprintf(stderr, "[ERROR] parse_tx_request: null argument\n");
         return -1;
     }
-
-    // account 필드 조회
-    cJSON *acct = cJSON_GetObjectItem(root, "account");
+    cJSON *root = cJSON_Parse(body);
+    if (!root) {
+        fprintf(stderr, "[ERROR] parse_tx_request: JSON parse failed\n");
+        return -1;
+    }
+    cJSON *acct = cJSON_GetObjectItem(root, "account_number");
     cJSON *amt  = cJSON_GetObjectItem(root, "amount");
-    if (!cJSON_IsNumber(acct) || !cJSON_IsNumber(amt)) {
-        LOG_ERR("parse_request: missing or non-number field");
-	cJSON_Delete(root);
+    if (!cJSON_IsString(acct) || !cJSON_IsNumber(amt)) {
+        fprintf(stderr, "[ERROR] parse_tx_request: missing or wrong type\n");
+        cJSON_Delete(root);
         return -2;
     }
+    // 문자열 복사
+    strncpy(out_acct_num, acct->valuestring, max_len - 1);
+    out_acct_num[max_len - 1] = '\0';
+    *out_amount = (long)amt->valuedouble;
+    cJSON_Delete(root);
+    return 0;
+}
 
-    // 값 저장
-    *out_account = acct->valueint;
-    *out_amount  = (long)amt->valuedouble;
-
+// 잔액 조회 요청 파싱 (account_number)
+int parse_balance_request(const char *body,
+                          char *out_acct_num, size_t max_len) {
+    if (!body || !out_acct_num) {
+        fprintf(stderr, "[ERROR] parse_balance_request: null argument\n");
+        return -1;
+    }
+    cJSON *root = cJSON_Parse(body);
+    if (!root) {
+        fprintf(stderr, "[ERROR] parse_balance_request: JSON parse failed\n");
+        return -1;
+    }
+    cJSON *acct = cJSON_GetObjectItem(root, "account_number");
+    if (!cJSON_IsString(acct)) {
+        fprintf(stderr, "[ERROR] parse_balance_request: missing or wrong type\n");
+        cJSON_Delete(root);
+        return -2;
+    }
+    strncpy(out_acct_num, acct->valuestring, max_len - 1);
+    out_acct_num[max_len - 1] = '\0';
     cJSON_Delete(root);
     return 0;
 }


### PR DESCRIPTION
계좌 입금/출금/잔액 조회 API를 모두 **`account_number`** 기준으로 변경

---

## 주요 변경사항

1. **DB 스키마**

   * `accounts` 테이블에 `account_number` 컬럼 추가
   * 기존 `id` 조회 로직을 모두 `account_number` 조회로 전환

2. **DB 레이어 (`db.h` / `db.c`)**

   * `db_deposit_by_number()`, `db_withdraw_by_number()` 추가
   * `db_get_balance()` (잔액 조회) 추가
   * 기존 `id` 바인딩 → `account_number` (문자열) 바인딩으로 수정

3. **Account 모듈 (`account.h` / `account.c`)**

   * `account_deposit()`, `account_withdraw()` 시그니처를 `const char *acct_num` 기반으로 변경
   * `account_get_balance()` 함수 추가

4. **JSON 유틸 (`json_util.h` / `json_util.c`)**

   * 거래 요청 파싱: `parse_tx_request(body, out_acct_num, max_len, &amount)` 도입
   * 잔액 조회 요청 파싱: `parse_balance_request(body, out_acct_num, max_len)` 도입

5. **HTTP 핸들러 (`http.c`)**

   * `/deposit`, `/withdraw` 로직을 `account_number` 필드로 처리하도록 수정
   * **신규** `/balance` 경로 추가하여 계좌번호 기준 잔액 조회 기능 구현
   * 잘못된 JSON, 계좌 미존재, 잔액 부족 에러 코드 및 메시지 처리 보완

---

## ✅ 검증 방법

```bash
# 사전: 테스트용 계좌 추가
mysql -u root -p zxcasdqwe5 -e "
INSERT INTO accounts (id, account_number, balance)
VALUES (1005, '1005-001-123456', 1000)
ON DUPLICATE KEY UPDATE balance=1000;
"

# 1) 입금 테스트
curl -i -X POST http://localhost:9090/deposit \
  -H "Content-Type: application/json" \
  -d '{"account_number":"1005-001-123456","amount":500}'

# 2) 출금 테스트
curl -i -X POST http://localhost:9090/withdraw \
  -H "Content-Type: application/json" \
  -d '{"account_number":"1005-001-123456","amount":200}'

# 3) 잔액 조회 테스트
curl -i -X POST http://localhost:9090/balance \
  -H "Content-Type: application/json" \
  -d '{"account_number":"1005-001-123456"}'
```

---

> 참고

* `account_number` UNIQUE 제약 덕분에 잘못된 요청 시 안전하게 404 처리됨.
* JSON 파싱 유효성 검사 강화로 잘못된 바디 요청 시 400 Bad Request 반환

