### PR TITLE
Hotfix/15: 간헐적으로 발생하는 invalid json 에러 해결

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -7,45 +7,75 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #define LOG_ERR(fmt, ...) \
     fprintf(stderr, "[ERROR] " fmt " (%s:%d)\n", ##__VA_ARGS__, __FILE__, __LINE__)
 
 #define BUFFER_SIZE 8192
 
-
 void handle_connection(int client_fd) {
     char buffer[BUFFER_SIZE];
-    // 1) 요청 읽기
-    int bytes_read = read(client_fd, buffer, sizeof(buffer) - 1);
-    if (bytes_read <= 0) {
-	LOG_ERR("handle_connection: read failed or connection closed (fd=%d)", client_fd);
+    int total_read = 0;
+    int header_end = -1;
+
+    // 1) 헤더 끝까지 읽기 (\r\n\r\n)
+    while (total_read < BUFFER_SIZE - 1) {
+        int n = read(client_fd, buffer + total_read, BUFFER_SIZE - 1 - total_read);
+        if (n <= 0) {
+            LOG_ERR("handle_connection: read failed or connection closed (fd=%d)", client_fd);
+            close(client_fd);
+            return;
+        }
+        total_read += n;
+        buffer[total_read] = '\0';
+        char *p = strstr(buffer, "\r\n\r\n");
+        if (p) {
+            header_end = (int)(p - buffer) + 4;
+            break;
+        }
+    }
+    if (header_end < 0) {
+        LOG_ERR("handle_connection: header not complete");
         close(client_fd);
         return;
     }
-    buffer[bytes_read] = '\0';
 
-    // 2) 요청 라인 파싱 (예: "POST /deposit HTTP/1.1")
+    // 2) Content-Length 파싱
+    int content_length = 0;
+    char *cl = strstr(buffer, "Content-Length:");
+    if (cl) {
+        cl += strlen("Content-Length:");
+        while (*cl == ' ') cl++;
+        content_length = atoi(cl);
+    }
+
+    // 3) 바디 끝까지 읽기
+    int body_bytes = total_read - header_end;
+    while (body_bytes < content_length && total_read < BUFFER_SIZE - 1) {
+        int n = read(client_fd, buffer + total_read, BUFFER_SIZE - 1 - total_read);
+        if (n <= 0) break;
+        total_read += n;
+        body_bytes = total_read - header_end;
+    }
+    buffer[total_read] = '\0';
+    char *body = buffer + header_end;
+
+    // 4) 요청 라인 파싱
     char method[16], path[256];
     if (sscanf(buffer, "%15s %255s", method, path) != 2) {
         LOG_ERR("handle_connection: invalid request line");
-	close(client_fd);
+        close(client_fd);
         return;
     }
     printf("Received request: %s %s\n", method, path);
 
-    // 3) 헤더 끝 다음부터 JSON 바디 시작
-    char *body = strstr(buffer, "\r\n\r\n");
-    if (body) body += 4;
-    else body = "";
-
-    // 4) 라우팅 및 비즈니스 로직 호출
+    // 5) 라우팅 및 비즈니스 로직
     int status_code = 200;
     char resp_body[256];
     size_t resp_len = 0;
 
     if (strcmp(path, "/deposit") == 0 && strcmp(method, "POST") == 0) {
-        char acct_num[32];
-        long amt, new_bal;
+        char acct_num[32]; long amt, new_bal;
         int rc = parse_tx_request(body, acct_num, sizeof(acct_num), &amt);
         if (rc == 0) {
             int dep = account_deposit(acct_num, amt, &new_bal);
@@ -64,8 +94,7 @@ void handle_connection(int client_fd) {
         }
     }
     else if (strcmp(path, "/withdraw") == 0 && strcmp(method, "POST") == 0) {
-        char acct_num[32];
-        long amt, new_bal;
+        char acct_num[32]; long amt, new_bal;
         int rc = parse_tx_request(body, acct_num, sizeof(acct_num), &amt);
         if (rc == 0) {
             int wd = account_withdraw(acct_num, amt, &new_bal);
@@ -88,8 +117,7 @@ void handle_connection(int client_fd) {
         }
     }
     else if (strcmp(path, "/balance") == 0 && strcmp(method, "POST") == 0) {
-        char acct_num[32];
-        long bal;
+        char acct_num[32]; long bal;
         int rc = parse_balance_request(body, acct_num, sizeof(acct_num));
         if (rc == 0) {
             int gb = account_get_balance(acct_num, &bal);
@@ -113,7 +141,7 @@ void handle_connection(int client_fd) {
             "{\"status\":\"FAIL\",\"reason\":\"Not Found\"}");
     }
 
-    // 5) 응답 헤더 전송
+    // 6) 응답 전송
     char header[256];
     int header_len = snprintf(header, sizeof(header),
         "HTTP/1.1 %d %s\r\n"
@@ -127,10 +155,10 @@ void handle_connection(int client_fd) {
          status_code == 409 ? "Conflict" : "Error"),
         resp_len
     );
-    write(client_fd, header, header_len);
-    write(client_fd, resp_body, resp_len);
+    (void)write(client_fd, header, header_len);
+    (void)write(client_fd, resp_body, resp_len);
 
-    // 6) 연결 종료
+    // 7) 연결 종료
     close(client_fd);
 }
 

--- a/src/http.c
+++ b/src/http.c
@@ -88,6 +88,7 @@ void handle_connection(int client_fd) {
                     "{\"status\":\"FAIL\",\"reason\":\"Account not found\"}");
             }
         } else {
+	    LOG_ERR("parse_tx_request error (code=%d), body=%.200s", rc, body);
             status_code = 400;
             resp_len = snprintf(resp_body, sizeof(resp_body),
                 "{\"status\":\"FAIL\",\"reason\":\"Invalid JSON\"}");
@@ -111,6 +112,7 @@ void handle_connection(int client_fd) {
                     "{\"status\":\"FAIL\",\"reason\":\"Account not found\"}");
             }
         } else {
+	    LOG_ERR("parse_tx_request error (code=%d), body=%.200s", rc, body);
             status_code = 400;
             resp_len = snprintf(resp_body, sizeof(resp_body),
                 "{\"status\":\"FAIL\",\"reason\":\"Invalid JSON\"}");
@@ -130,6 +132,7 @@ void handle_connection(int client_fd) {
                     "{\"status\":\"FAIL\",\"reason\":\"Account not found\"}");
             }
         } else {
+            LOG_ERR("parse_tx_request error (code=%d), body=%.200s", rc, body);
             status_code = 400;
             resp_len = snprintf(resp_body, sizeof(resp_body),
                 "{\"status\":\"FAIL\",\"reason\":\"Invalid JSON\"}");


### PR DESCRIPTION
# gdb 디버깅(에러 파악)

<img width="692" alt="image" src="https://github.com/user-attachments/assets/6f6d8839-c640-4a00-9a7f-6c9da3f16c95" />

- `buffer[bytes_read]` 값이 63(코드상 설정된 최대 값이 64임 -> **`#define BUFFER_SIZE 8192`**)
- `x/s buffer`를 보면 파싱하지 못한 JSON 바디가 남아 있는 것을 볼 수 있음

---

  - 즉, 정리하자면
  - 간헐적으로 Invalid JSON 에러가 발생하던 근본 원인은 TCP 소켓에서 한 번의 read() 호출만으로 헤더와 바디를 동시에 다 받으려다 보니, 헤더만 들어오고 JSON 바디가 남아 있는 경우가 생겼기 때문이고,
  - 이렇게 헤더만 버퍼에 들어오면 parse_tx_request() 에선 잘린 문자열을 넘겨받아 cJSON_Parse()가 실패하게 됐기 때문에 에러가 발생했던 것이었음!!

## 이제 잘 됩니다..

<img width="527" alt="image" src="https://github.com/user-attachments/assets/4aa593f2-8d27-4a4a-9469-c40e9f3e3b51" />

### 추가 참고사항

> 이제 Invalid JSON 발생 시, 보다 정밀한 에러 로그가 출력됩니다 ~
