### PR TITLE
Feat: Keycloak JWKS 인증용 nginx.conf 파일 추가

### DIFF
--- a/nginx/bank-server.conf
+++ b/nginx/bank-server.conf
@@ -1,0 +1,65 @@
+# /etc/nginx/sites-available/bank-server.conf
+
+http {
+    # DNS 리졸버 설정 (JWKS를 HTTPS로 가져올 때 필요)
+    resolver 8.8.8.8;
+
+    # JWT 공개 키(JWKS) 캐시 저장소
+    proxy_cache_path /var/cache/nginx/jwks_cache levels=1:2 keys_zone=jwks_cache:10m inactive=1h;
+
+    server {
+        # ─────────── HTTPS: 클라이언트 요청 수신 ───────────
+        listen 443 ssl http2;
+        server_name bank.wonq.store;
+
+        # ─────────── SSL 인증서 ───────────
+        # Let's Encrypt 등을 통해 발급받은 bank.wonq.store 인증서 경로
+        ssl_certificate     /etc/letsencrypt/live/bank.wonq.store/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/bank.wonq.store/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+
+        # ─────────── 1) JWKS 캐시용 내부 엔드포인트 ───────────
+        # 외부에서 직접 접근 불가; NGINX 내부에서만 호출
+        location = /_jwks_cached {
+            internal;
+            proxy_pass https://192.168.0.151:9090/realms/wonq-realm/protocol/openid-connect/certs;
+            proxy_cache jwks_cache;
+            proxy_cache_valid 200 1h;
+            proxy_cache_use_stale error timeout updating;
+        }
+
+        # ─────────── 2) JWT 검증 후 C 서버로 프록시 ───────────
+        location / {
+            # Bank API 보호용 JWT 인증 활성화
+            auth_jwt "Bank API";
+
+            # JWKS(공개 키 집합) 요청을 내부 경로로 대체
+            auth_jwt_key_request /_jwks_cached;
+
+            # Keycloak RS256 알고리즘 사용
+            auth_jwt_alg RS256;
+
+            # issuer 클레임 검증 (Keycloak Realm URL)
+            auth_jwt_claim_set iss "http://192.168.0.151:9090/realms/wonq-realm";
+
+            # audience 클레임 검증 (Keycloak에 등록된 bank-server Client ID)
+            auth_jwt_claim_set aud "bank-server";
+
+            # 인증 성공 시 C 서버 (bank_server, 9090포트)로 프록시
+            proxy_pass http://127.0.0.1:9090;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Authorization "";  # 이미 인증 완료되었으므로 삭제
+        }
+    }
+
+    # ─────────── 3) HTTP → HTTPS 강제 리디렉트 (선택 사항) ───────────
+    server {
+        listen 80;
+        server_name bank.wonq.store;
+
+        return 301 https://$host$request_uri;
+    }
+}
+


### PR DESCRIPTION
## 요약
- C로 구현된 계정계 API 서버(bank-server)를 보호하기 위해 JWT 기반 인증을 도입할 필요가 있었습니다.
- Keycloak을 인증 서버로 사용하고, NGINX의 `ngx_http_auth_jwt_module`을 통해 요청 단계에서 JWT 검증을 처리하도록 수정했습니다.
- 공개 키 집합(JWKS)을 캐싱하여 Keycloak 서버로의 불필요한 요청을 최소화하고 인증 처리 속도를 개선했습니다.

## What Changed
1. 새로운 NGINX 설정 파일 `/etc/nginx/sites-available/bank-server.conf` 추가
2. JWT 공개 키(JWKS) 캐시를 위한 내부 엔드포인트 `/ _jwks_cached` 설정
3. `auth_jwt` 모듈을 활용해 Keycloak Realm(`wonq-realm`)의 RS256 공개 키로 토큰 검증
4. 검증 성공 시 C로 구현된 계정계 서버(127.0.0.1:9090)로 Proxy
5. HTTP(80) → HTTPS(443) 강제 리디렉트 설정